### PR TITLE
docs: sprint 2 retrospective and lessons learned

### DIFF
--- a/.claude/sprint_status.json
+++ b/.claude/sprint_status.json
@@ -1,6 +1,7 @@
 {
   "current_sprint": 2,
-  "phase": "6 - PR Creation",
+  "phase": "complete",
   "branch": "feature/20260417_Sprint_2",
+  "pr": "https://github.com/jbarkie/betbot/pull/20",
   "issues": [18, 19]
 }

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -84,6 +84,9 @@
 
 ## Lessons Learned (Running Log)
 
+**Sprint 2 (2026-04-17)**
+- For Angular major-version upgrades, check `npm show @angular/core version --tag latest` before planning — `ng update` dry-run only steps one major at a time and does not reflect the true latest version on npm
+
 **Sprint 1 (2026-04-17)**
 - Specify which component owns state in AC: container components own loading/error; presentational components own display-only states
 - `data-testid` attributes make tests more resilient to CSS changes — use them for test-facing elements

--- a/docs/retrospectives/SPRINT_2_RETROSPECTIVE.md
+++ b/docs/retrospectives/SPRINT_2_RETROSPECTIVE.md
@@ -1,0 +1,34 @@
+# Sprint 2 Retrospective
+
+**Date:** 2026-04-17
+**Goal:** Upgrade Angular frontend from v19 to v21 (via v20), NgRx to v21, jest to v30
+**PR:** https://github.com/jbarkie/betbot/pull/20
+**Outcome:** All 6 acceptance criteria met
+
+## Acceptance Criteria
+
+| Criterion | Status |
+|---|---|
+| All `@angular/*` packages at `^21.x` | ✅ 21.2.9 / CLI 21.2.7 |
+| `ng build` clean at both v20 and v21 checkpoints | ✅ 0 errors, 0 warnings |
+| Schematic output committed separately at each hop | ✅ |
+| All `@ngrx/*` at Angular-21-compatible versions | ✅ 21.1.0 |
+| `npm test` passes all 219 tests | ✅ |
+| `typescript` satisfies Angular 21's required range | ✅ 5.9.3 |
+
+## Surprises and Blockers
+
+- `ng update` dry-run only showed Angular 20 — user correctly identified v21 was available; confirmed via `npm show @angular/core version --tag latest`
+- npm cache had root-owned files; required manual `sudo chown` outside of tool calls
+- `jest-preset-angular@14` peer dep rejected `@angular/core >=20`; blocked Angular 21 hop until jest tooling was upgraded first
+- NgRx and jest-preset-angular had a circular peer conflict; resolved by installing both in a single `npm install` invocation
+- NgRx v21 install initially ran from project root instead of `frontend/`; caught during version verification
+
+## Lessons Learned
+
+- For Angular major-version upgrades, check `npm show @angular/core version --tag latest` before planning — `ng update` dry-run only steps one major at a time
+
+## Notes
+
+- Angular 21 schematic auto-migrated 9 components to `@if`/`@for` block control flow syntax — net improvement to codebase style
+- picomatch high-severity ReDoS vulnerability surfaced and resolved via `npm audit fix` during the upgrade


### PR DESCRIPTION
## Summary

Closes out Sprint 2 — adds the retrospective file and updates the master plan with the single approved lesson learned (check `npm show` for true latest Angular version before planning an upgrade sprint).

## What Changed

- **docs/retrospectives/SPRINT_2_RETROSPECTIVE.md**: Sprint 2 retro file
- **docs/ALL_SPRINTS_MASTER_PLAN.md**: Sprint 2 outcome recorded; lesson learned added
- **.claude/sprint_status.json**: Sprint 2 marked complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)